### PR TITLE
Implement branch tree using artifact hooks

### DIFF
--- a/src/components/BranchTree.tsx
+++ b/src/components/BranchTree.tsx
@@ -1,0 +1,87 @@
+import { GitBranch, ChevronRight, ChevronDown } from 'lucide-react'
+import { useBranches } from '@artifact/client/hooks'
+import { useState } from 'react'
+
+interface BranchNodeProps {
+  path: string
+  name: string
+  selected: string | null
+  onSelect: (branch: string) => void
+}
+
+const BranchNode: React.FC<BranchNodeProps> = ({
+  path,
+  name,
+  selected,
+  onSelect
+}) => {
+  const fullPath = path ? `${path}/${name}` : name
+  const children = useBranches(fullPath)
+  const [expanded, setExpanded] = useState(false)
+  const hasChildren = children && children.length > 0
+
+  return (
+    <div className="ml-2">
+      <div
+        className={`flex items-center p-1 rounded cursor-pointer ${
+          selected === fullPath
+            ? 'bg-blue-50 text-blue-700'
+            : 'hover:bg-gray-50'
+        }`}
+        onClick={() => onSelect(fullPath)}
+      >
+        {hasChildren && (
+          <button
+            className="mr-1 text-gray-500"
+            onClick={(e) => {
+              e.stopPropagation()
+              setExpanded(!expanded)
+            }}
+          >
+            {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          </button>
+        )}
+        <GitBranch size={14} className="mr-1 text-gray-500" />
+        <span className="text-sm">{name}</span>
+      </div>
+      {expanded && hasChildren && (
+        <div className="ml-4">
+          {children!.map((child) => (
+            <BranchNode
+              key={child}
+              path={fullPath}
+              name={child}
+              selected={selected}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface BranchTreeProps {
+  selected: string | null
+  onSelect: (branch: string) => void
+}
+
+const BranchTree: React.FC<BranchTreeProps> = ({ selected, onSelect }) => {
+  const branches = useBranches()
+  if (!branches) return null
+  return (
+    <div className="space-y-1">
+      {branches.map((name) => (
+        <BranchNode
+          key={name}
+          path=""
+          name={name}
+          selected={selected}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default BranchTree

--- a/src/components/RemotesList.tsx
+++ b/src/components/RemotesList.tsx
@@ -1,0 +1,22 @@
+import { useRemotes } from '@artifact/client/hooks'
+import React from 'react'
+
+const RemotesList: React.FC = () => {
+  const remotes = useRemotes()
+  if (!remotes) return null
+  return (
+    <div className="mt-4">
+      <h4 className="font-medium mb-2">Remotes</h4>
+      <ul className="space-y-1 text-sm">
+        {remotes.map((r) => (
+          <li key={r.name} className="flex justify-between">
+            <span>{r.name}</span>
+            <span className="text-gray-500">{r.url}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default RemotesList


### PR DESCRIPTION
## Summary
- use `useBranches` and `useRemotes` hooks
- add recursive `BranchTree` component
- show remotes list
- call `onSelection` via `useFrame`
- add modals for new branch and fork actions

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_685240a47454832bb8cc6925aa587767