### PR TITLE
Display real commit history

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,85 +21,7 @@ import { useFrame, useArtifact } from '@artifact/client/hooks'
 import type { BranchScope } from '@artifact/client/api'
 import BranchTree from './components/BranchTree'
 import RemotesList from './components/RemotesList'
-import type { Commit } from './types/git'
-
-// Mock commit data
-const mockCommits: Commit[] = [
-  {
-    id: 'c1',
-    hash: '8a7b9c5d3e1f2a0b8c7d6e5f4a3b2c1d0e9f8a7b',
-    shortHash: '8a7b9c5',
-    message: 'Fix navbar responsive design issues',
-    author: 'Alex Johnson',
-    date: '2023-06-15T10:30:00Z',
-    branch: 'main',
-    tags: ['v1.2.0']
-  },
-  {
-    id: 'c2',
-    hash: '7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c',
-    shortHash: '7b6c5d4',
-    message: 'Add authentication middleware',
-    author: 'Sam Davis',
-    date: '2023-06-14T15:45:00Z',
-    branch: 'main'
-  },
-  {
-    id: 'c3',
-    hash: '6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d',
-    shortHash: '6c5d4e3',
-    message: 'Update API documentation',
-    author: 'Taylor Smith',
-    date: '2023-06-13T09:15:00Z',
-    branch: 'main'
-  },
-  {
-    id: 'c4',
-    hash: '5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e',
-    shortHash: '5d4e3f2',
-    message: 'Merge feature/user-profiles into develop',
-    author: 'Robin Garcia',
-    date: '2023-06-12T14:20:00Z',
-    branch: 'develop'
-  },
-  {
-    id: 'c5',
-    hash: '4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f',
-    shortHash: '4e3f2a1',
-    message: 'Add user profile settings page',
-    author: 'Casey Wilson',
-    date: '2023-06-11T11:10:00Z',
-    branch: 'feature/user-profiles'
-  },
-  {
-    id: 'c6',
-    hash: '3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4e',
-    shortHash: '3f2a1b0',
-    message: 'Initial implementation of user profiles',
-    author: 'Casey Wilson',
-    date: '2023-06-10T16:30:00Z',
-    branch: 'feature/user-profiles'
-  },
-  {
-    id: 'c7',
-    hash: '2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4e3f',
-    shortHash: '2a1b0c9',
-    message: 'Fix pagination bug on dashboard',
-    author: 'Alex Johnson',
-    date: '2023-06-09T10:45:00Z',
-    branch: 'hotfix/pagination'
-  },
-  {
-    id: 'c8',
-    hash: '1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4e3f2a',
-    shortHash: '1b0c9d8',
-    message: 'Update dependencies and security patches',
-    author: 'Sam Davis',
-    date: '2023-06-08T09:20:00Z',
-    branch: 'main',
-    tags: ['v1.1.0']
-  }
-]
+import useCommitHistory from './hooks/useCommitHistory'
 
 const App: React.FC = () => {
   const { data, update } = useBranchSettings()
@@ -118,7 +40,8 @@ const App: React.FC = () => {
     'graph'
   )
 
-  const filteredCommits = mockCommits.filter((commit) => {
+  const commits = useCommitHistory(selectedBranch)
+  const filteredCommits = (commits ?? []).filter((commit) => {
     const matchesSearch =
       searchTerm === '' ||
       commit.message.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -182,7 +105,7 @@ const App: React.FC = () => {
   }
 
   const selectedCommitDetails = selectedCommit
-    ? mockCommits.find((c) => c.id === selectedCommit)
+    ? (commits?.find((c) => c.id === selectedCommit) ?? null)
     : null
 
   return (

--- a/src/hooks/useCommitHistory.ts
+++ b/src/hooks/useCommitHistory.ts
@@ -1,0 +1,62 @@
+import { useArtifact } from '@artifact/client/hooks'
+import { useEffect, useState } from 'react'
+import type { Commit } from '../types/git'
+
+const SHORT_HASH_LEN = 7
+
+function toIsoDate(timestamp: number, offset: number): string {
+  return new Date((timestamp + offset * 60) * 1000).toISOString()
+}
+
+export default function useCommitHistory(
+  branch: string | null,
+  limit = 50
+): Commit[] | undefined {
+  const artifact = useArtifact()
+  const [commits, setCommits] = useState<Commit[]>()
+
+  useEffect(() => {
+    if (!artifact || !branch) {
+      setCommits(undefined)
+      return
+    }
+
+    let active = true
+    const scoped = artifact.checkout({ branch })
+
+    const load = async () => {
+      try {
+        const hashes = await scoped.branch.read.history(limit)
+        const list: Commit[] = []
+        for (const hash of hashes) {
+          const commit = await scoped
+            .checkout({ commit: hash })
+            .branch.read.commit()
+          list.push({
+            id: hash,
+            hash,
+            shortHash: hash.slice(0, SHORT_HASH_LEN),
+            message: commit.message,
+            author: commit.author.name,
+            date: toIsoDate(
+              commit.author.timestamp,
+              commit.author.timezoneOffset
+            ),
+            branch
+          })
+        }
+        if (active) setCommits(list)
+      } catch (e) {
+        console.error(e)
+        if (active) setCommits(undefined)
+      }
+    }
+
+    load()
+    return () => {
+      active = false
+    }
+  }, [artifact, branch, limit])
+
+  return commits
+}


### PR DESCRIPTION
## Summary
- use `artifact.branch.read.history` to fetch commits
- add `useCommitHistory` hook
- show commit list using actual branch commits

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6854cfb22f00832bb5cdc83026aba8d7