### PR TITLE
Improve commit rendering

### DIFF
--- a/src/components/CommitDiff.tsx
+++ b/src/components/CommitDiff.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { ArtifactSyncer } from '@artifact/client/react'
+import { useCommit, useFileDiff } from '@artifact/client/hooks'
+import { EMPTY_COMMIT } from '@artifact/client/api'
+
+interface CommitDiffProps {
+  oid: string
+}
+
+const CommitDiff: React.FC<CommitDiffProps> = ({ oid }) => (
+  <ArtifactSyncer commit={oid}>
+    <InnerDiff oid={oid} />
+  </ArtifactSyncer>
+)
+
+const InnerDiff: React.FC<CommitDiffProps> = ({ oid }) => {
+  const commit = useCommit(oid)
+  const parent = commit?.parent?.[0] ?? EMPTY_COMMIT
+  const diff = useFileDiff({ other: parent })
+
+  if (!diff) {
+    return (
+      <div>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="animate-pulse h-4 bg-gray-100 rounded mb-1"
+          ></div>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="font-mono text-sm text-gray-600">
+      {diff.added.map((m) => (
+        <div key={m.path} className="text-green-600">
+          + {m.path}
+        </div>
+      ))}
+      {diff.removed.map((m) => (
+        <div key={m.path} className="text-red-600">
+          - {m.path}
+        </div>
+      ))}
+      {diff.modified.map((m) => (
+        <div key={m.path} className="text-gray-600">
+          {' '}
+          {m.path}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default CommitDiff

--- a/src/components/CommitList.tsx
+++ b/src/components/CommitList.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react'
+import { useBranch } from '@artifact/client/hooks'
+import CommitRow from './CommitRow'
+
+interface CommitListProps {
+  selectedCommit: string | null
+  onSelect: (oid: string) => void
+  filter?: string
+}
+
+const INITIAL_LIMIT = 20
+const LOAD_COUNT = 20
+
+const CommitList: React.FC<CommitListProps> = ({
+  selectedCommit,
+  onSelect,
+  filter
+}) => {
+  const [limit, setLimit] = useState(INITIAL_LIMIT)
+  const { history } = useBranch(limit)
+
+  const loadMore = () => setLimit((l) => l + LOAD_COUNT)
+
+  if (!history) {
+    return (
+      <div>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="border-b border-gray-100 p-3">
+            <div className="animate-pulse h-6 bg-gray-100 rounded w-3/4 mb-1"></div>
+            <div className="animate-pulse h-4 bg-gray-100 rounded w-1/2"></div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {history.map((oid) => (
+        <CommitRow
+          key={oid}
+          oid={oid}
+          selected={selectedCommit === oid}
+          onSelect={onSelect}
+          filter={filter}
+        />
+      ))}
+      {history.length >= limit && (
+        <button
+          className="w-full py-2 text-sm text-blue-600 hover:underline"
+          onClick={loadMore}
+        >
+          Load More
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default CommitList

--- a/src/components/CommitRow.tsx
+++ b/src/components/CommitRow.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { GitCommit, Clock } from 'lucide-react'
+import { useCommit } from '@artifact/client/hooks'
+
+interface CommitRowProps {
+  oid: string
+  selected: boolean
+  onSelect: (oid: string) => void
+  filter?: string
+}
+
+const SHORT_HASH_LEN = 7
+
+function toIsoDate(timestamp: number, offset: number): string {
+  return new Date((timestamp + offset * 60) * 1000).toISOString()
+}
+
+const CommitRow: React.FC<CommitRowProps> = ({
+  oid,
+  selected,
+  onSelect,
+  filter
+}) => {
+  const commit = useCommit(oid)
+
+  if (!commit) {
+    return (
+      <div className="border-b border-gray-100 p-3">
+        <div className="animate-pulse h-6 bg-gray-100 rounded w-3/4 mb-1"></div>
+        <div className="animate-pulse h-4 bg-gray-100 rounded w-1/2"></div>
+      </div>
+    )
+  }
+
+  const shortHash = oid.slice(0, SHORT_HASH_LEN)
+
+  const getCommitDate = (dateString: string) => {
+    const date = new Date(dateString)
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+  }
+
+  const date = toIsoDate(commit.author.timestamp, commit.author.timezoneOffset)
+
+  if (
+    filter &&
+    !commit.message.toLowerCase().includes(filter.toLowerCase()) &&
+    !commit.author.name.toLowerCase().includes(filter.toLowerCase()) &&
+    !shortHash.toLowerCase().includes(filter.toLowerCase())
+  ) {
+    return null
+  }
+
+  return (
+    <div
+      className={`border-b border-gray-100 p-3 hover:bg-gray-50 cursor-pointer transition-colors ${selected ? 'bg-blue-50' : ''}`}
+      onClick={() => onSelect(oid)}
+    >
+      <div className="flex items-start">
+        <div className="text-gray-500 mr-3 mt-1">
+          <GitCommit size={16} />
+        </div>
+        <div className="flex-1">
+          <div className="font-medium">{commit.message}</div>
+          <div className="flex items-center text-sm mt-1">
+            <span className="text-blue-600 font-mono">{shortHash}</span>
+            <span className="mx-2 text-gray-400">•</span>
+            <span className="text-gray-600">{commit.author.name}</span>
+            <span className="mx-2 text-gray-400">•</span>
+            <span className="text-gray-500 flex items-center">
+              <Clock size={12} className="mr-1" />
+              {getCommitDate(date)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CommitRow


### PR DESCRIPTION
## Summary
- show commits with new components
- fetch commit details with useCommit
- fetch file diffs with useFileDiff
- show loading skeletons and limit commit list

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_685506f84b24832b8cc75bc1cfa086e3