### PR TITLE
Update modal positioning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,9 +21,11 @@ import CommitList from './components/CommitList'
 import CommitDiff from './components/CommitDiff'
 import { useCommit } from '@artifact/client/hooks'
 import { EMPTY_COMMIT } from '@artifact/client/api'
+import useViewport from './hooks/useViewport'
 
 const App: React.FC = () => {
   const frame = useFrame()
+  const viewport = useViewport()
   const [searchTerm, setSearchTerm] = useState('')
   const [selectedCommit, setSelectedCommit] = useState<string | null>(null)
   const [selectedBranch, setSelectedBranch] = useState<string | null>('main')
@@ -206,7 +208,16 @@ const App: React.FC = () => {
         </div>
 
         {showCommitDetails && selectedCommit && (
-          <div className="fixed inset-0 bg-black/20 flex items-center justify-center z-50">
+          <div
+            style={{
+              position: 'absolute',
+              top: viewport.scrollY,
+              left: viewport.scrollX,
+              width: viewport.width,
+              height: viewport.height
+            }}
+            className="bg-black/20 flex items-center justify-center z-50"
+          >
             <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-auto">
               <div className="flex items-center justify-between p-4 border-b border-gray-200">
                 <h3 className="text-lg font-medium">Commit Details</h3>

--- a/src/hooks/useViewport.ts
+++ b/src/hooks/useViewport.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+
+export default function useViewport() {
+  const [size, setSize] = useState(() => ({
+    width: typeof window !== 'undefined' ? window.innerWidth : 0,
+    height: typeof window !== 'undefined' ? window.innerHeight : 0,
+    scrollX: typeof window !== 'undefined' ? window.scrollX : 0,
+    scrollY: typeof window !== 'undefined' ? window.scrollY : 0
+  }))
+
+  useEffect(() => {
+    const handler = () => {
+      setSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+        scrollX: window.scrollX,
+        scrollY: window.scrollY
+      })
+    }
+    window.addEventListener('resize', handler)
+    window.addEventListener('scroll', handler)
+    return () => {
+      window.removeEventListener('resize', handler)
+      window.removeEventListener('scroll', handler)
+    }
+  }, [])
+
+  return size
+}


### PR DESCRIPTION
## Summary
- create `useViewport` hook to capture viewport size and scroll
- use the viewport data to absolutely position commit details modal

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_68589af03168832b8b913408b9c8116a